### PR TITLE
feat(ui): tui row selection, status bar footer, and shell prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,7 @@ Every first-class route should have a corresponding `index.html.md.ts` endpoint 
 - Avoid heavy borders, shadows, blur, and oversized containers unless the user explicitly asks for them.
 - Prefer links and lists over boxed CTAs. The UI should feel closer to a personal terminal page than a SaaS landing page.
 - Keep motion subtle and rare. Keyboard-driven navigation should stay instant with no decorative animation.
+- List rows opt into TUI selection with `data-tui-row`: reverse-video hover, a `>` gutter cursor, and `j`/`k` + `enter` keyboard navigation (script in `site-layout.astro`, styles unlayered at the end of `global.css` so the inversion beats Tailwind utilities). New link lists should use it — but only for text rows; rows containing media (posters, images) skip it, the full-width inversion breaks there.
+- "Cards" are TUI panes when explicitly requested: 1px `border-border`, square corners, no shadow/fill, label overlapping the top border (see `/work` projects). Never SaaS cards.
+- Page intros can show a shell prompt (`prompt`/`cwd` props on `page-intro.astro`, e.g. `glpecile@web:~/blog$ ls *.mdx`); the home hero also has a blinking `▊` cursor (`.tui-cursor`, respects reduced motion).
+- The footer is a sticky TUI status bar showing the current path as a shell cwd (`~`, `~/blog`) — keep it slim and single-row.

--- a/src/components/film-list.tsx
+++ b/src/components/film-list.tsx
@@ -18,10 +18,18 @@ type Layout = "grid" | "timeline";
 
 type FilmsResponse = { films: LetterboxdFilm[] };
 
+// `watchedDate` is date-only (`YYYY-MM-DD`). `new Date(str)` parses that as
+// UTC midnight, which shifts the rendered day in negative-UTC timezones and
+// breaks SSR/client hydration when the two disagree. Parse as a local
+// calendar date so both sides always render the same day.
+const parseLocalDate = (dateStr: string) => {
+	const [year = 0, month = 1, day = 1] = dateStr.split("-").map(Number);
+	return new Date(year, month - 1, day);
+};
+
 const formatDate = (dateStr: string | null) => {
 	if (!dateStr) return "";
-	const date = new Date(dateStr);
-	return date.toLocaleDateString("en-US", {
+	return parseLocalDate(dateStr).toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",
@@ -30,14 +38,13 @@ const formatDate = (dateStr: string | null) => {
 
 const getMonthKey = (dateStr: string | null) => {
 	if (!dateStr) return "unknown";
-	const date = new Date(dateStr);
+	const date = parseLocalDate(dateStr);
 	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 };
 
 const getMonthLabel = (dateStr: string | null) => {
 	if (!dateStr) return "";
-	const date = new Date(dateStr);
-	return date.toLocaleDateString("en-US", {
+	return parseLocalDate(dateStr).toLocaleDateString("en-US", {
 		month: "long",
 		year: "numeric",
 	});
@@ -68,6 +75,8 @@ const groupFilmsByMonth = <T extends LetterboxdFilm>(filmList: T[]) => {
 // by the same inline blur. Matching the `src` lets the browser reuse the loaded
 // image when the island hydrates, so there is no reload flash. (The runtime
 // `/_image` optimizer 404s on this prerendered site, so raw URLs are required.)
+// The 1px frame makes each poster read like a TUI pane; the grid brightens it
+// on hover like a focused one.
 const Poster = ({
 	film,
 	className,
@@ -82,7 +91,7 @@ const Poster = ({
 		height={450}
 		loading="lazy"
 		style={film.blur ? { backgroundImage: `url(${film.blur})` } : undefined}
-		className={`bg-muted aspect-[2/3] bg-cover bg-center object-cover ${className}`}
+		className={`bg-muted border-border aspect-[2/3] border bg-cover bg-center object-cover ${className}`}
 	/>
 );
 
@@ -96,13 +105,16 @@ const FilmGrid = ({ films }: { films: FilmWithBlur[] }) => (
 					rel="noopener noreferrer"
 					className="group block"
 				>
-					{film.image ? (
-						<Poster film={film} className="w-full" />
-					) : (
-						<div className="bg-muted aspect-[2/3] w-full p-3">
-							<p className="text-tone-mid text-sm leading-relaxed">{film.title}</p>
-						</div>
-					)}
+				{film.image ? (
+					<Poster
+						film={film}
+						className="group-hover:border-tone-mid w-full transition-colors duration-150 motion-reduce:transition-none"
+					/>
+				) : (
+					<div className="bg-muted border-border group-hover:border-tone-mid aspect-[2/3] w-full border p-3 transition-colors duration-150 motion-reduce:transition-none">
+						<p className="text-tone-mid text-sm leading-relaxed">{film.title}</p>
+					</div>
+				)}
 					<p className="mt-2 text-sm leading-snug">
 						<span className="text-foreground group-hover:underline group-focus-visible:underline">
 							{film.title}

--- a/src/components/more-link.astro
+++ b/src/components/more-link.astro
@@ -9,7 +9,11 @@ const { href, label = "...more" } = Astro.props;
 
 <a class="terminal-link group inline-flex items-center gap-2 text-sm" href={href}>
 	<span>{label}</span>
-	<svg viewBox="0 0 16 16" aria-hidden="true" class="h-4 w-4 fill-current transition-transform duration-150 ease-out group-hover:rotate-45 group-focus-visible:rotate-45 motion-reduce:transform-none motion-reduce:transition-none">
+	<svg
+		viewBox="0 0 16 16"
+		aria-hidden="true"
+		class="h-4 w-4 fill-current transition-transform duration-150 ease-out group-hover:rotate-45 group-focus-visible:rotate-45 motion-reduce:transform-none motion-reduce:transition-none"
+	>
 		<path d="M3.75 4a.75.75 0 0 0 0 1.5h6.69l-7.22 7.22a.75.75 0 1 0 1.06 1.06l7.22-7.22v6.69a.75.75 0 0 0 1.5 0V4.75A.75.75 0 0 0 12.25 4h-8.5Z"></path>
 	</svg>
 </a>

--- a/src/components/page-intro.astro
+++ b/src/components/page-intro.astro
@@ -6,18 +6,32 @@ export interface Props {
 	title: string;
 	description: string;
 	extra?: string;
+	/** Render a faint shell prompt line above the title, e.g. `glpecile@web:~$ whoami`. */
+	prompt?: string;
+	/** Working directory shown in the prompt, e.g. `~/blog`. Defaults to `~`. */
+	cwd?: string;
+	/** Append a blinking block cursor to the title, like a shell awaiting input. */
+	cursor?: boolean;
 }
 
-const { label, title, description, extra } = Astro.props;
+const { label, title, description, extra, prompt, cwd = "~", cursor = false } = Astro.props;
 ---
 
 <section class="space-y-4">
 	<SectionLabel label={label} data-reveal />
+	{prompt && (
+		<p class="text-sm sm:text-base" data-reveal>
+			<span class="text-tone-faint">glpecile@web:{cwd}$</span>{" "}
+			<span class="text-tone-mid">{prompt}</span>
+		</p>
+	)}
 	<h1
 		class="page-heading max-w-3xl text-3xl font-bold tracking-tight sm:text-4xl"
 		data-reveal
 	>
-		{title}
+		{title}{cursor && (
+			<span aria-hidden="true" class="tui-cursor">▊</span>
+		)}
 	</h1>
 	{description && (
 		<p class="text-tone-mid max-w-3xl text-sm leading-8 sm:text-base" data-reveal>

--- a/src/components/section-label.astro
+++ b/src/components/section-label.astro
@@ -1,10 +1,16 @@
 ---
 export interface Props {
 	label: string;
+	/** Append a hairline rule that fills the remaining width, like a TUI panel separator. */
+	rule?: boolean;
+	class?: string;
 	[key: string]: unknown;
 }
 
-const { label, ...rest } = Astro.props;
+const { label, rule = true, class: className, ...rest } = Astro.props;
 ---
 
-<p class="section-label" {...rest}>* {label}</p>
+<p class:list={["section-label", rule && "flex items-center gap-3", className]} {...rest}>
+	<span class="shrink-0">* {label}</span>
+	{rule && <span aria-hidden="true" class="bg-border h-px flex-1"></span>}
+</p>

--- a/src/components/site-footer.astro
+++ b/src/components/site-footer.astro
@@ -1,15 +1,23 @@
 ---
 import { siteConfig } from "#config/site";
 
+export interface Props {
+	currentPath: string;
+}
+
+const { currentPath } = Astro.props;
 const themeItems = siteConfig.shortcuts.theme;
+
+// Render the current path like a shell cwd: `~` at home, `~/blog` elsewhere.
+const termPath =
+	currentPath === "/" ? "~" : `~${currentPath.replace(/\/+$/, "")}`;
 ---
 
-<footer class="text-tone-soft pt-12 text-sm">
-	<p class="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
-		<span class="inline-flex items-center gap-2">
-			<svg viewBox="0 0 16 16" aria-hidden="true" class="text-tone-mid h-4 w-4 fill-current">
-				<path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
-			</svg>
+<footer class="text-tone-soft bg-background sticky bottom-0 z-10 -mx-6 mt-12 text-sm sm:-mx-8">
+	<div class="border-border mx-6 border-t sm:mx-8">
+		<p class="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 py-2">
+		<span class="inline-flex items-center gap-4">
+			<span class="text-tone-faint">{termPath}</span>
 			<a
 				class="terminal-link text-tone-mid"
 				href={`${siteConfig.links.github}/glpecile.xyz`}
@@ -49,7 +57,8 @@ const themeItems = siteConfig.shortcuts.theme;
 				</button>
 			))}
 		</span>
-	</p>
+		</p>
+	</div>
 </footer>
 
 <script is:inline>

--- a/src/layouts/site-layout.astro
+++ b/src/layouts/site-layout.astro
@@ -231,7 +231,7 @@ const jsonLd = {
 			<slot />
 			</main>
 
-			<SiteFooter />
+			<SiteFooter currentPath={currentPath} />
 		</div>
 
 		<script is:inline data-shortcuts={JSON.stringify(shortcuts)}>
@@ -292,9 +292,112 @@ const jsonLd = {
 			})();
 		</script>
 
-		<script is:inline>
-			(() => {
-				const element = document.querySelector("[data-scramble]");
+	<script is:inline>
+		(() => {
+			const editableTags = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+			let selectedIndex = -1;
+
+			const getRows = () =>
+				Array.from(document.querySelectorAll("[data-tui-row]"));
+
+			const setSelected = (index) => {
+				const rows = getRows();
+				selectedIndex = index;
+				rows.forEach((row, rowIndex) => {
+					if (rowIndex === selectedIndex) {
+						row.setAttribute("data-tui-selected", "");
+					} else {
+						row.removeAttribute("data-tui-selected");
+					}
+				});
+			};
+
+			const moveSelection = (delta) => {
+				const rows = getRows();
+				if (rows.length === 0) {
+					return;
+				}
+
+				const next =
+					selectedIndex === -1
+						? delta > 0
+							? 0
+							: rows.length - 1
+						: (selectedIndex + delta + rows.length) % rows.length;
+
+				setSelected(next);
+				rows[next].scrollIntoView({ block: "nearest" });
+			};
+
+			const openRow = (row) => {
+				const link = row instanceof HTMLElement ? row.querySelector("a[href]") : null;
+				if (link instanceof HTMLAnchorElement) {
+					link.click();
+				}
+			};
+
+			document.addEventListener("keydown", (event) => {
+				if (
+					event.defaultPrevented ||
+					event.repeat ||
+					event.metaKey ||
+					event.ctrlKey ||
+					event.altKey
+				) {
+					return;
+				}
+
+				const target = event.target;
+
+				if (
+					target instanceof HTMLElement &&
+					(editableTags.has(target.tagName) ||
+						target.isContentEditable ||
+						target instanceof HTMLAnchorElement)
+				) {
+					return;
+				}
+
+				if (event.key === "j") {
+					event.preventDefault();
+					moveSelection(1);
+				} else if (event.key === "k") {
+					event.preventDefault();
+					moveSelection(-1);
+				} else if (event.key === "Enter" && selectedIndex !== -1) {
+					event.preventDefault();
+					openRow(getRows()[selectedIndex]);
+				} else if (event.key === "Escape") {
+					setSelected(-1);
+				}
+			});
+
+			// Clicking anywhere on a row follows its primary link, unless the
+			// click landed on an interactive element or selected text.
+			document.addEventListener("click", (event) => {
+				const target = event.target;
+				if (!(target instanceof Element)) {
+					return;
+				}
+
+				const row = target.closest("[data-tui-row]");
+				if (!row || target.closest("a, button")) {
+					return;
+				}
+
+				const selection = window.getSelection();
+				if (selection && selection.toString().length > 0) {
+					return;
+				}
+
+				openRow(row);
+			});
+		})();
+	</script>
+
+	<script is:inline>
+		(() => {
+			const element = document.querySelector("[data-scramble]");
 				const text = element?.getAttribute("data-text") ?? "";
 				const prefersReducedMotion = window.matchMedia(
 					"(prefers-reduced-motion: reduce)",

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -40,6 +40,7 @@ const postPath = `/blog/${post.id}`;
 		<a
 			href="/blog"
 			class="blog-back-link terminal-link inline-flex items-center gap-2 text-sm"
+			data-tui-row
 			data-reveal
 		>
 			<svg

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -11,6 +11,7 @@ const latestPostRange = `1-${latestPostCount}`;
 const recentPostUrls = posts
 	.slice(0, latestPostCount)
 	.map((post) => getBlogPostUrl(post.id));
+const introExtra = `use <span class="text-tone-mid">[${latestPostRange}]</span> for the latest posts · <span class="text-tone-mid">[j]/[k]</span> to move · <span class="text-tone-mid">[enter]</span> to open.<span class="mt-2 block">or subscribe via the <a class="terminal-link" href="/blog/rss.xml">rss feed</a>.</span>`;
 ---
 
 <SiteLayout
@@ -24,6 +25,9 @@ const recentPostUrls = posts
 			label="blog"
 			title="Notes, builds, and rabbit holes."
 			description="From tiny thoughts to full project writeups. Every post is just an mdx file — the latest nine get a keyboard shortcut."
+			extra={posts.length > 0 ? introExtra : undefined}
+			prompt="ls *.mdx"
+			cwd="~/blog"
 		/>
 
 		{posts.length === 0 ? (
@@ -31,12 +35,15 @@ const recentPostUrls = posts
 		) : (
 			<ol class="space-y-5" data-reveal>
 				{posts.map((post, index) => (
-					<li class="space-y-1">
+					<li data-tui-row class="group space-y-1">
 						<p class="text-tone-faint text-xs tracking-[0.28em] uppercase">
 							{formatDate(post.data.updatedDate ?? post.data.pubDate)}
 						</p>
 						<p class="text-base leading-8 sm:text-lg">
-							<a class="terminal-link" href={getBlogPostUrl(post.id)}>
+							<a
+								class="terminal-link group-hover:underline"
+								href={getBlogPostUrl(post.id)}
+							>
 								{post.data.title}
 							</a>
 							{index < latestPostCount && (
@@ -51,16 +58,6 @@ const recentPostUrls = posts
 			</ol>
 		)}
 
-		{posts.length > 0 && (
-			<div class="text-tone-soft space-y-1 text-sm" data-reveal>
-				<p>
-					use <span class="text-tone-mid">[{latestPostRange}]</span> for the latest posts.
-				</p>
-				<p>
-					or subscribe via the <a class="terminal-link" href="/blog/rss.xml">rss feed</a>.
-				</p>
-			</div>
-		)}
 	</section>
 
 	<script

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const navShortcutCopy = siteConfig.shortcuts.nav
 			`<span class="text-tone-mid">[${item.shortcut}] ${item.title.toLowerCase()}</span>`,
 	)
 	.join('<span class="text-tone-faint"> / </span>');
-const introExtra = `shortcut keys: ${navShortcutCopy}<span class="mt-2 block">are you an agent? start with <a class="terminal-link" href="/llms.txt">/llms.txt</a>.</span>`;
+const introExtra = `shortcut keys: ${navShortcutCopy}<span class="mt-2 block">move with <span class="text-tone-mid">[j]/[k]</span>, open with <span class="text-tone-mid">[enter]</span>.</span><span class="mt-2 block">are you an agent? start with <a class="terminal-link" href="/llms.txt">/llms.txt</a>.</span>`;
 ---
 
 <SiteLayout>
@@ -43,6 +43,8 @@ const introExtra = `shortcut keys: ${navShortcutCopy}<span class="mt-2 block">ar
 		title="Software / Frontend Engineer."
 		description="I don't build everything. I just build what I build."
 		extra={introExtra}
+		prompt="whoami"
+		cursor
 	/>
 
 	<section class="space-y-4" data-reveal>
@@ -53,12 +55,15 @@ const introExtra = `shortcut keys: ${navShortcutCopy}<span class="mt-2 block">ar
 		) : (
 			<ol class="space-y-4">
 				{latestPosts.map((post) => (
-					<li class="grid gap-1 sm:grid-cols-[8.5rem_minmax(0,1fr)] sm:items-baseline sm:gap-x-5">
+					<li data-tui-row class="group grid gap-1 sm:grid-cols-[8.5rem_minmax(0,1fr)] sm:items-baseline sm:gap-x-5">
 						<p class="text-tone-faint text-sm leading-7 sm:text-base">
 							{formatDate(post.data.updatedDate ?? post.data.pubDate).toLowerCase()}
 						</p>
 						<p class="text-base leading-8 sm:text-lg">
-							<a class="terminal-link" href={getBlogPostUrl(post.id)}>
+							<a
+								class="terminal-link group-hover:underline"
+								href={getBlogPostUrl(post.id)}
+							>
 								{post.data.title}
 							</a>
 						</p>
@@ -99,15 +104,17 @@ const introExtra = `shortcut keys: ${navShortcutCopy}<span class="mt-2 block">ar
 	<section class="space-y-3" data-reveal>
 		<SectionLabel label="socials" />
 		<ul class="space-y-2 text-sm sm:text-base">
-			{socialLinks.map(([label, href]) => (
-				<li>
+			{socialLinks.map(([label, href], index) => (
+				<li data-tui-row class="group">
 					<a
 						href={href}
 						target="_blank"
 						rel="noopener noreferrer"
-					class="terminal-link inline-flex items-center gap-3"
+					class="terminal-link inline-flex items-center gap-2 group-hover:underline"
 				>
-						<span class="text-tone-faint">-</span>
+						<span class="text-tone-faint" aria-hidden="true">
+							{index === socialLinks.length - 1 ? "└──" : "├──"}
+						</span>
 						<span class="capitalize">{label}</span>
 					</a>
 				</li>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -40,6 +40,8 @@ const cvFileName = cvDownloadName();
 			label="work"
 			title="Past work experience."
 			description="+ projects, skills, education & certificates."
+			prompt="history"
+			cwd="~/work"
 		/>
 
 		<div class="space-y-2" data-reveal>
@@ -67,8 +69,13 @@ const cvFileName = cvDownloadName();
 		)}
 	</section>
 
-	<section class="space-y-4" data-reveal>
-		<SectionLabel label="projects" />
+	<section data-reveal>
+		<div class="border-border relative border px-5 py-6 sm:px-6">
+			<SectionLabel
+				label="projects"
+				rule={false}
+				class="bg-background absolute -top-[0.55em] left-3 px-2 leading-none"
+			/>
 
 		{projects.length === 0 ? (
 			<p class="text-tone-soft text-sm">no projects yet.</p>
@@ -117,6 +124,7 @@ const cvFileName = cvDownloadName();
 				))}
 			</ol>
 		)}
+		</div>
 	</section>
 
 	<section class="space-y-4" data-reveal>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -536,7 +536,27 @@
 		margin: 2rem 0;
 	}
 
+	/* Blinking block cursor for the home hero. Static under reduced motion. */
+	.tui-cursor {
+		animation: tui-cursor-blink 1.1s step-end infinite;
+	}
+
+	@keyframes tui-cursor-blink {
+		0%,
+		100% {
+			opacity: 1;
+		}
+
+		50% {
+			opacity: 0;
+		}
+	}
+
 	@media (prefers-reduced-motion: reduce) {
+		.tui-cursor {
+			animation: none;
+		}
+
 		.blog-back-link-icon,
 		.blog-prose .blog-heading-status {
 			transition: none;
@@ -637,4 +657,55 @@
 
 :root[data-theme="dark"] .map-frame .mapboxgl-ctrl-icon {
 	filter: invert(1);
+}
+
+/*
+	TUI row selection: reverse-video highlight with a `>` gutter cursor, like
+	a focused row in a terminal menu. Rows opt in with [data-tui-row]; the
+	layout script moves [data-tui-selected] with j/k and opens with enter.
+	Unlayered on purpose — like the map-frame overrides above — so the
+	inversion flattens Tailwind's tone/link color utilities on descendants.
+*/
+[data-tui-row] {
+	position: relative;
+}
+
+[data-tui-row][data-tui-selected],
+[data-tui-row]:focus-within {
+	background: hsl(var(--foreground));
+	color: hsl(var(--background));
+}
+
+[data-tui-row][data-tui-selected] :is(a, p, span, time, div),
+[data-tui-row]:focus-within :is(a, p, span, time, div) {
+	color: inherit;
+}
+
+[data-tui-row][data-tui-selected]::before,
+[data-tui-row]:focus-within::before {
+	color: hsl(var(--foreground));
+	content: ">";
+	position: absolute;
+	left: -1.6ch;
+	top: 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+	[data-tui-row]:hover {
+		background: hsl(var(--foreground));
+		color: hsl(var(--background));
+		cursor: pointer;
+	}
+
+	[data-tui-row]:hover :is(a, p, span, time, div) {
+		color: inherit;
+	}
+
+	[data-tui-row]:hover::before {
+		color: hsl(var(--foreground));
+		content: ">";
+		position: absolute;
+		left: -1.6ch;
+		top: 0;
+	}
 }


### PR DESCRIPTION
## Summary

The site already had a terminal aesthetic — monospace, `[h]` key hints, git-log timeline — but lists had no *selected row*, the core interaction primitive of real TUIs. This adds it, plus chrome that makes each page read like a terminal session: a sticky status bar with the current path as a shell cwd, shell-prompt intros per page, and a bordered pane for projects. It also fixes films watched-dates rendering the wrong day and breaking hydration for anyone behind UTC.

## What changed

- **Row selection** — text rows (home blog list, blog index, socials, back-to-blog) opt into `data-tui-row`: reverse-video hover with a `>` gutter cursor, `j`/`k` to move, `enter` to open, and whole-row click. The inversion styles are unlayered CSS on purpose so they flatten Tailwind's tone/link utilities on selected descendants. Media rows (films timeline) deliberately skip the treatment — full-width inversion over posters reads broken.
- **Status bar footer** — sticky bottom bar: shell cwd (`~`, `~/blog`) on the left, theme picker on the right. The top rule stays content-width while the background bleeds past it, so timeline markers scrolling underneath stay masked.
- **Shell prompts** — page intros take `prompt`/`cwd` props: `glpecile@web:~$ whoami` on home, `~/blog$ ls *.mdx` on blog, `~/work$ history` on work. Home's h1 also gets a blinking `▊` cursor, static under reduced motion.
- **Panes, rules, glyphs** — `/work` projects are a 1px bordered pane with the label cut into the top border (the TUI version of cards — no shadows, no rounding); section labels fill their row with a hairline; socials use `├──`/`└──`; the `...more ↗` arrow rotates to `→` on hover.
- **Films date fix** — `watchedDate` is date-only (`YYYY-MM-DD`) and `new Date(str)` parses that as UTC midnight, so UTC-negative visitors saw the previous day and the island hydration-mismatched on every row. Dates now parse as a local calendar date; posters also get a 1px frame that brightens on grid hover.

## Validation

Headless-browser pass against the dev server: home renders 4 posters, `/films` renders 50, the island hydrates with zero console errors (previously a hydration mismatch per film row, and before that a broken island from a stale vite dep cache). `astro check`, `oxlint` + `rustywind`, and all 20 vitest tests pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![kimi-k3](https://img.shields.io/badge/kimi--k3-000000)
