### PR TITLE
fix(cv): wrap long skill labels and unify on JetBrains Mono

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@astrojs/cloudflare": "14.1.4",
         "@astrojs/mdx": "7.0.3",
         "@astrojs/react": "^6.0.1",
-        "@fontsource/geist-mono": "^5.3.0",
         "@fontsource/jetbrains-mono": "^5.3.0",
         "@pdf-lib/fontkit": "^1.1.1",
         "@radix-ui/react-slot": "^1.3.3",
@@ -293,8 +292,6 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
-
-    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.3.0", "", {}, "sha512-UtJ1BBBCVpMYdIcW7nEB45UAoAw5M53ZXs2t0ciPW+IokuAAIc56M8+kW5tXbRJCTpDw4XTtU7proT6NdQAHTg=="],
 
     "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.3.0", "", {}, "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@astrojs/cloudflare": "14.1.4",
 		"@astrojs/mdx": "7.0.3",
 		"@astrojs/react": "^6.0.1",
-		"@fontsource/geist-mono": "^5.3.0",
 		"@fontsource/jetbrains-mono": "^5.3.0",
 		"@pdf-lib/fontkit": "^1.1.1",
 		"@radix-ui/react-slot": "^1.3.3",

--- a/src/layouts/site-layout.astro
+++ b/src/layouts/site-layout.astro
@@ -1,4 +1,6 @@
 ---
+import jetBrainsMonoRegularUrl from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2?url";
+
 import meAvatar from "@/assets/me-avatar.webp?inline";
 import SiteFooter from "@/components/site-footer.astro";
 import SiteNav from "@/components/site-nav.astro";
@@ -117,11 +119,12 @@ const jsonLd = {
 		<link rel="icon" href="/favicon.ico" sizes="any" />
 		<link rel="apple-touch-icon" href="/apple-icon.png" />
 		<link rel="manifest" href="/manifest.webmanifest" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 		<link
-			href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700;800&display=swap"
-			rel="stylesheet"
+			rel="preload"
+			href={jetBrainsMonoRegularUrl}
+			as="font"
+			type="font/woff2"
+			crossorigin="anonymous"
 		/>
 		<script is:inline>
 			(() => {

--- a/src/pages/work/cv.pdf.ts
+++ b/src/pages/work/cv.pdf.ts
@@ -3,8 +3,8 @@ import { PDFDocument, PDFName, PDFString, rgb } from "pdf-lib";
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { APIRoute } from "astro";
 
-import geistMonoBoldDataUrl from "@fontsource/geist-mono/files/geist-mono-latin-700-normal.woff?inline";
-import geistMonoRegularDataUrl from "@fontsource/geist-mono/files/geist-mono-latin-400-normal.woff?inline";
+import jetBrainsMonoBoldDataUrl from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-700-normal.woff?inline";
+import jetBrainsMonoRegularDataUrl from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff?inline";
 
 import { cvDownloadName } from "@/lib/cv";
 import { flattenInlineLinks } from "@/lib/inline-links";
@@ -458,10 +458,17 @@ function buildInlineGridBlock(ctx: Ctx, rows: CvInlineRow[]): Block {
 	const valueLineGroups = rows.map((row) =>
 		wrapText(ctx.regular, row.value, layout.entryMetaSize, valueWidth),
 	);
+	// Labels wrap too, so a long category never bleeds into the value column.
+	const labelLineGroups = rows.map((row) =>
+		wrapText(ctx.bold, row.label, layout.entryMetaSize, layout.inlineLabelWidth),
+	);
+
+	const cellLines = (index: number) =>
+		Math.max(labelLineGroups[index]?.length ?? 0, valueLineGroups[index]?.length ?? 0);
 
 	const pairHeight = (index: number) => {
-		const leftLines = valueLineGroups[index]?.length ?? 1;
-		const rightLines = valueLineGroups[index + 1]?.length ?? 0;
+		const leftLines = cellLines(index) || 1;
+		const rightLines = index + 1 < rows.length ? cellLines(index + 1) : 0;
 		return Math.max(leftLines, rightLines) * lineBox(layout.entryMetaSize, layout.entryMetaLineHeight) + layout.inlineRowGap;
 	};
 
@@ -474,19 +481,27 @@ function buildInlineGridBlock(ctx: Ctx, rows: CvInlineRow[]): Block {
 		let y = top;
 
 		for (let index = 0; index < rows.length; index += 2) {
-			const drawCell = (row: CvInlineRow | undefined, lines: string[] | undefined, cellX: number) => {
+			const drawCell = (
+				row: CvInlineRow | undefined,
+				lines: string[] | undefined,
+				labelLines: string[] | undefined,
+				cellX: number,
+			) => {
 				if (!row) {
 					return;
 				}
 
-				const labelBaseline = y - layout.entryMetaSize * layout.baselineFactor;
-				page.drawText(row.label, {
-					x: cellX,
-					y: labelBaseline,
-					size: layout.entryMetaSize,
-					font: ctx.bold,
-					color: colors.foreground,
-				});
+				let labelY = y;
+				for (const line of labelLines ?? [row.label]) {
+					page.drawText(line, {
+						x: cellX,
+						y: labelY - layout.entryMetaSize * layout.baselineFactor,
+						size: layout.entryMetaSize,
+						font: ctx.bold,
+						color: colors.foreground,
+					});
+					labelY -= lineBox(layout.entryMetaSize, layout.entryMetaLineHeight);
+				}
 
 				let lineY = y;
 				for (const line of lines ?? [row.value]) {
@@ -501,8 +516,8 @@ function buildInlineGridBlock(ctx: Ctx, rows: CvInlineRow[]): Block {
 				}
 			};
 
-			drawCell(rows[index], valueLineGroups[index], x0);
-			drawCell(rows[index + 1], valueLineGroups[index + 1], x0 + cellWidth);
+			drawCell(rows[index], valueLineGroups[index], labelLineGroups[index], x0);
+			drawCell(rows[index + 1], valueLineGroups[index + 1], labelLineGroups[index + 1], x0 + cellWidth);
 
 			y -= pairHeight(index);
 		}
@@ -583,8 +598,8 @@ export const GET: APIRoute = async () => {
 
 	const ctx: Ctx = {
 		pdf,
-		regular: await pdf.embedFont(decodeDataUrl(geistMonoRegularDataUrl), { subset: true }),
-		bold: await pdf.embedFont(decodeDataUrl(geistMonoBoldDataUrl), { subset: true }),
+		regular: await pdf.embedFont(decodeDataUrl(jetBrainsMonoRegularDataUrl), { subset: true }),
+		bold: await pdf.embedFont(decodeDataUrl(jetBrainsMonoBoldDataUrl), { subset: true }),
 	};
 
 	const pages = paginate(buildBlocks(ctx));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+/* Self-hosted JetBrains Mono (latin only). Weights match what the UI uses:
+   400 body, 500 `font-medium`, 700 `font-bold`. */
+@import "@fontsource/jetbrains-mono/latin-400.css";
+@import "@fontsource/jetbrains-mono/latin-500.css";
+@import "@fontsource/jetbrains-mono/latin-700.css";
+
 @theme {
 	--font-mono: "JetBrains Mono", monospace;
 	--font-sans: "JetBrains Mono", monospace;


### PR DESCRIPTION
The skills grid drew each category label as a single unwrapped line, so
labels wider than `inlineLabelWidth` (150px) bled into the value column —
"Design Systems & Craft" already collided at the current content. Labels
now wrap like values do, and row height accounts for whichever column is
taller.

The CV PDF was also the only consumer of Geist Mono while the rest of the
site (global.css, mermaid diagrams, OG images) runs on JetBrains Mono.
Embed JetBrains Mono instead and drop @fontsource/geist-mono, so the
generated CV matches the site's typography.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HkmjtS7QYHZR8aEbJ1ZrPA